### PR TITLE
Configure eslint to complain on no newline after var definition

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "no-trailing-spaces": 2,
     "max-len": [2, 100, 4],
     "semi": [2, "always"],
+    "newline-after-var": [2, "always"]
   },
   "env": {
     "node": true

--- a/lib/bin-helpers/command.js
+++ b/lib/bin-helpers/command.js
@@ -30,6 +30,7 @@ function ensureCMAtoken (env, command) {
     let msg = error.format(command)(
       'CONTENTFUL_MANAGEMENT_ACCESS_TOKEN is undefined or empty'
     );
+
     console.error(msg);
     process.exit(1);
   }

--- a/lib/bin-helpers/flags.js
+++ b/lib/bin-helpers/flags.js
@@ -120,6 +120,7 @@ function optionDescriptorsForCommand (command) {
 
     if (_.contains(applicableTo, command) || _.contains(applicableTo, 'all')) {
       let clone = _.omit(value, 'for');
+
       _.extend(clone, refinement);
       acc[key] = clone;
     }

--- a/lib/command/delete.js
+++ b/lib/command/delete.js
@@ -18,6 +18,7 @@ module.exports = function (options, context) {
       })
       .then(function (response) {
         let version = response.sys.version;
+
         options.version = version;
 
         return new Widget(options, context).delete()

--- a/lib/command/update.js
+++ b/lib/command/update.js
@@ -48,6 +48,7 @@ function loadCurrentVersion (options, context) {
   return new Widget(options, context).read()
     .then(function (response) {
       let version = response.sys.version;
+
       options.version = version;
       return options;
     });

--- a/test/integration/commands-test.js
+++ b/test/integration/commands-test.js
@@ -37,6 +37,7 @@ describe('Commands', function () {
 
   beforeEach(function () {
     let env = _.clone(process.env);
+
     env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN = 'lol-token';
 
     execOptions = {env: env};

--- a/test/integration/descriptor-file-test.js
+++ b/test/integration/descriptor-file-test.js
@@ -49,6 +49,7 @@ describe('Descriptor file', function () {
 
   beforeEach(function () {
     let env = _.clone(process.env);
+
     env.CONTENTFUL_MANAGEMENT_ACCESS_TOKEN = 'lol-token';
 
     execOptions = {env: env};
@@ -116,6 +117,7 @@ describe('Descriptor file', function () {
           .catch(function (error) {
             let cause = `ENOENT: no such file or directory, stat '${customDescriptorPath}'`;
             let msg = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+
             expect(error.error.code).to.eq(1);
             expect(error.stderr).to.match(msg);
           });
@@ -150,6 +152,7 @@ describe('Descriptor file', function () {
           .catch(function (error) {
             let cause = 'EACCES: permission denied, open \'.+\/descriptor\.json\'';
             let msg = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+
             expect(error.error.code).to.eq(1);
             expect(error.stderr).to.match(msg);
           });
@@ -465,6 +468,7 @@ describe('Descriptor file', function () {
             .catch(function (error) {
               let cause = '.+\/widget\.json Unexpected token o';
               let regexp = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+
               expect(error.error.code).to.eq(1);
               expect(error.stderr).to.match(regexp);
             });
@@ -486,6 +490,7 @@ describe('Descriptor file', function () {
             .then(assert.fail)
             .catch(function (error) {
               let regexp = new RegExp(`Failed to ${commandName} the widget`);
+
               expect(error.error.code).to.eq(1);
               expect(error.stderr).to.match(regexp);
             });
@@ -507,6 +512,7 @@ describe('Descriptor file', function () {
             .then(assert.fail)
             .catch(function (error) {
               let msg = new RegExp(`Failed to ${commandName} the widget: missing src and srcdoc in descriptor file`);
+
               expect(error.error.code).to.eq(1);
               expect(error.stderr).to.match(msg);
             });
@@ -582,6 +588,7 @@ describe('Descriptor file', function () {
               .catch(function (error) {
                 let cause = `ENOENT: no such file or directory, stat '${customDescriptorPath}'`;
                 let msg = new RegExp(`Failed to ${commandName} the widget: ${cause}`);
+
                 expect(error.error.code).to.eq(1);
                 expect(error.stderr).to.match(msg);
               });

--- a/test/integration/http-server.js
+++ b/test/integration/http-server.js
@@ -22,6 +22,7 @@ app.use(function (req, res, next) {
 app.all('/spaces/:space/widgets/:id', function (req, res, next) {
   if (req.params.id === 'not-found') {
     let error = buildError('NotFoundError', 'The resource can\'t be found');
+
     res.status(404);
     res.send(error);
     res.end();
@@ -62,6 +63,7 @@ app.put('/spaces/:space/widgets/:id', function (req, res) {
   } else {
     if (req.params.id === 'fail-update') {
       let error = buildError();
+
       res.status(500);
       res.send(error);
       res.end();
@@ -73,6 +75,7 @@ app.put('/spaces/:space/widgets/:id', function (req, res) {
       res.end();
     } else {
       let sys = widget.sys;
+
       widget = req.body;
       widget.sys = sys;
       widget.sys.version = widget.sys.version + 1;
@@ -88,6 +91,7 @@ app.get('/spaces/:space/widgets', function (req, res) {
 
   if (req.params.space === 'fail') {
     let error = buildError();
+
     res.status(500);
     res.send(error);
     res.end();
@@ -113,6 +117,7 @@ app.delete('/spaces/:space/widgets/:id', function (req, res) {
 
   if (req.params.id === 'fail-delete') {
     let error = buildError();
+
     res.status(500);
     res.send(error);
     res.end();
@@ -153,6 +158,7 @@ function buildError (id, message) {
 }
 
 var server;
+
 exports.start = function start () {
   server = app.listen(3000);
 };

--- a/test/unit/cli/widget-test.js
+++ b/test/unit/cli/widget-test.js
@@ -9,6 +9,7 @@ var Widget = require('../../../lib/widget');
 
 function buildWidgetPayload (options) {
   var widget = {};
+
   _.extend(widget, _.pick(options, ['src', 'srcdoc', 'fieldTypes']));
 
   if (options.fieldTypes) {
@@ -44,6 +45,7 @@ function buildWidgetPayload (options) {
 
 describe('Widget', function () {
   let context, options, widget, http;
+
   beforeEach(function () {
     http = {
       post: sinon.stub().returns(Bluebird.resolve()),
@@ -85,6 +87,7 @@ describe('Widget', function () {
       describe('when a version has been provided', function () {
         it('it calls the http.put method including the version', function () {
           let payload = buildWidgetPayload({src: options.src});
+
           options = _.extend(options, {version: 66});
 
           return widget.save().then(function () {


### PR DESCRIPTION
## Summary

Configure `eslint` to complaint about missing newlines after variable definitions http://eslint.org/docs/rules/newline-after-var
